### PR TITLE
Fix the storybook for the LoginHeader component

### DIFF
--- a/src/components/login_header.tsx
+++ b/src/components/login_header.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import styled from "styled-components"
-import Icon from "./icons"
+import Icon from "./icon"
 
 const Header = styled.header`
   margin: 20px;


### PR DESCRIPTION
The storybook for the `LoginHeader` component is broken due to a path issue.

![screen shot 2017-03-01 at 11 07 13 am](https://cloud.githubusercontent.com/assets/386234/23469657/3157a528-fe72-11e6-86aa-5951b0d56955.png)
