### PR TITLE
TextLink in ArtworkDetails should have a key

### DIFF
--- a/src/components/artwork/details.tsx
+++ b/src/components/artwork/details.tsx
@@ -19,7 +19,7 @@ export class ArtworkDetails extends React.Component<DetailsProps, null> {
     } else if (artists && artists.length) {
       let artistsEl = []
       for (let i = 0; i < artists.length; i++) {
-        artistsEl.push(<TextLink href={ artists[i].href }>{ artists[i].name }</TextLink>)
+        artistsEl.push(<TextLink href={ artists[i].href } key={ i }>{ artists[i].name }</TextLink>)
         if (i !== artists.length - 1) {
           artistsEl.push(<span>,</span>)
         }


### PR DESCRIPTION
This removes the warning below:

![screen shot 2017-03-01 at 3 58 27 pm](https://cloud.githubusercontent.com/assets/386234/23481065/22c4aa4e-fe98-11e6-80f8-1943133be4fe.png)
