### PR TITLE
explicitly declare __id to makre sure it is always available

### DIFF
--- a/src/components/artwork/details.tsx
+++ b/src/components/artwork/details.tsx
@@ -77,6 +77,7 @@ export default Relay.createContainer(ArtworkDetails , {
         sale_message
         cultural_maker
         artists(shallow: true) {
+          __id
           href
           name
         }


### PR DESCRIPTION
Following up on @alloy's comment: https://github.com/artsy/reaction-force/pull/36#discussion_r103796738