### PR TITLE
@l2succes => Move inquiries route handling to separate file + a few more tests

### DIFF
--- a/src/apps/loyalty/__mocks__/isomorphic-relay.ts
+++ b/src/apps/loyalty/__mocks__/isomorphic-relay.ts
@@ -1,3 +1,3 @@
 module.exports = {
-  container: container => container
+  container: container => container,
 }

--- a/src/apps/loyalty/__mocks__/isomorphic-relay.ts
+++ b/src/apps/loyalty/__mocks__/isomorphic-relay.ts
@@ -1,0 +1,3 @@
+module.exports = {
+  container: container => container
+}

--- a/src/apps/loyalty/__tests__/server.tsx
+++ b/src/apps/loyalty/__tests__/server.tsx
@@ -10,6 +10,14 @@ describe ("Home page", () => {
   })
 })
 
+describe("ThankYouHTML", () => {
+  it("renders the acb template for confirmed buyers", () => {
+    let profile = { confirmed_buyer_at: "trust me im a buyer" } as any
+    let html = ThankYouHtml(profile)
+    expect(html).toMatch("EARLY ACCESS")
+  })
+})
+
 describe ("ThankYou page", () => {
   it("redirects to /login if there is no user", () => {
     let req = { baseUrl: "loyalty" } as any
@@ -17,5 +25,18 @@ describe ("ThankYou page", () => {
     let next = jest.fn() as any
     ThankYou(req, res, next)
     expect(res.redirect).toHaveBeenCalledWith("loyalty/login")
+  })
+
+  it("redirects to /loyalty if the user is not a loyalty applicant", () => {
+    let get = () => {
+      return {
+        loyalty_applicant_at: null,
+      }
+    }
+    let req = { baseUrl: "loyalty", user: { get } } as any
+    let res = { redirect: jest.fn() } as any
+    let next = jest.fn() as any
+    ThankYou(req, res, next)
+    expect(res.redirect).toHaveBeenCalledWith("loyalty")
   })
 })

--- a/src/apps/loyalty/containers/inquiries/__tests__/__snapshots__/index.tsx.snap
+++ b/src/apps/loyalty/containers/inquiries/__tests__/__snapshots__/index.tsx.snap
@@ -1,0 +1,99 @@
+exports[`login renders the inquiries listing 1`] = `
+<div
+  className="bXZydp">
+  <div
+    className="hiqXMD">
+    <div
+      className="dHhWkf">
+      <div
+        className="gQelpA"
+        style={undefined}>
+        
+      </div>
+    </div>
+    <a
+      className="iDuDUI"
+      href="/">
+      Back To Artsy
+    </a>
+  </div>
+  <header
+    className="dtwjRD">
+    <div
+      className="header-title ccrmRr">
+      Please select all works you purchased
+    </div>
+    <p
+      className="header-subtitle fLunyJ">
+      We will confirm submitted purchases with the galleries in order to qualify you for the program membership.
+    </p>
+  </header>
+  <div
+    className="artworks">
+    <div
+      className="gGgzvo">
+      <div
+        className="jhQCSn">
+        <div
+          className="erlken">
+          <div
+            className="loRosL">
+            <div
+              className="iCSZmV"
+              onClick={[Function]}
+              size={250}>
+              <div
+                className="fmQTpg"
+                size={250}>
+                <img
+                  className="eltJDW"
+                  size={250}
+                  src="http://path.to.cat.pics" />
+              </div>
+              <div
+                className="tEGyX">
+                <div>
+                  <div>
+                    <strong>
+                      <a
+                        className="jehOuL"
+                        href="/percy-z">
+                        Percy Z
+                      </a>
+                    </strong>
+                  </div>
+                  <a
+                    className="jehOuL"
+                    href={undefined}>
+                    <em />
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <footer
+    className="footer">
+    <p
+      className="fTgPgI">
+      If you purchased any works not included
+      <br />
+       above, please list them.
+    </p>
+    <textarea
+      className="NrqUR"
+      onChange={[Function]}
+      placeholder="Artwork, Artist, Gallery" />
+    <button
+      className="jkaRYz"
+      onClick={[Function]}>
+      <span>
+        Submit purchases
+      </span>
+    </button>
+  </footer>
+</div>
+`;

--- a/src/apps/loyalty/containers/inquiries/__tests__/index.tsx
+++ b/src/apps/loyalty/containers/inquiries/__tests__/index.tsx
@@ -1,0 +1,60 @@
+import * as React from "react"
+import * as ReactTestUtils from "react-dom/test-utils"
+import * as renderer from "react-test-renderer"
+
+import { Inquiries } from "../index"
+
+const inquiryProps = {
+  user: {
+    artwork_inquiries_connection: {
+      edges: [
+        {
+          node: {
+            id: "andy-warhol-skull",
+            impulse_conversation_id: "1",
+            artwork: {
+              image: {
+                url: "http://path.to.cat.pics",
+              },
+              artists: [{
+                name: "Percy Z",
+                href: "/percy-z",
+              }],
+            },
+          },
+        },
+        {
+          node: {
+            id: "andy-warhol-skullz",
+            impulse_conversation_id: null,
+            artwork: {
+              image: {
+                url: "http://path.to.cat.pics",
+              },
+              artists: [{
+                name: "Percy Z Without Conversation",
+                href: "/percy-z-without-conversation",
+              }],
+            },
+          },
+        },
+      ],
+    },
+  },
+} as any
+
+describe("login", () => {
+  it("renders the inquiries listing", () => {
+    const inquiries = renderer.create(<Inquiries {...inquiryProps}/>)
+    expect(inquiries).toMatchSnapshot()
+  })
+
+  it("renders the artist information", () => {
+    const inquiries = ReactTestUtils.renderIntoDocument(<Inquiries {...inquiryProps}/>)
+    const aTags = ReactTestUtils.scryRenderedDOMComponentsWithTag(inquiries, "a")
+    const artistLink = aTags.find(tag => tag.href === "/percy-z" && tag.textContent === "Percy Z")
+    expect(artistLink).toBeTruthy()
+    const noConvoLink = aTags.find(tag => tag.href === "/percy-z-without-conversation")
+    expect(noConvoLink).toBeUndefined()
+  })
+})

--- a/src/apps/loyalty/server/index.tsx
+++ b/src/apps/loyalty/server/index.tsx
@@ -2,8 +2,6 @@ import * as artsyPassport from "artsy-passport"
 import * as Backbone from "backbone"
 import * as express from "express"
 import * as path from "path"
-import * as React from "react"
-import * as Relay from "react-relay"
 
 import RelayMiddleware from "./middlewares/relay"
 import UserMiddleware from "./middlewares/user"

--- a/src/apps/loyalty/server/index.tsx
+++ b/src/apps/loyalty/server/index.tsx
@@ -1,22 +1,13 @@
 import * as artsyPassport from "artsy-passport"
 import * as Backbone from "backbone"
 import * as express from "express"
-import { default as IsomorphicRelay } from "isomorphic-relay"
 import * as path from "path"
 import * as React from "react"
 import * as Relay from "react-relay"
 
-import { renderToString } from "react-dom/server"
-import * as styleSheet from "styled-components/lib/models/StyleSheet"
-import renderPage from "./template"
-
-import CurrentUserRoute from "../../../relay/queries/current_user"
-
-import Inquiries from "../containers/inquiries"
-import { markCollectorAsLoyaltyApplicant } from "./gravity"
 import RelayMiddleware from "./middlewares/relay"
 import UserMiddleware from "./middlewares/user"
-import { Home, Login, ThankYou } from "./route_handlers"
+import { Home, Inquiries, Login, ThankYou } from "./route_handlers"
 
 const app = express.Router()
 const { API_URL } = process.env
@@ -38,42 +29,6 @@ app.use(UserMiddleware)
 app.get("/", Home)
 app.get(loginPagePath, Login)
 app.get("/thank-you", ThankYou)
-
-app.get("/inquiries", (req, res) => {
-  if (!req.user) {
-    return res.redirect(req.baseUrl + loginPagePath)
-  }
-
-  const info = req.user.get("profile")
-  if (info.loyalty_applicant_at) {
-    return res.redirect(req.baseUrl + "/thank-you")
-  }
-
-  if (info.confirmed_buyer_at) {
-    markCollectorAsLoyaltyApplicant(req.user.get("accessToken"))
-      .then(profile => {
-        return res.redirect(req.baseUrl + "/thank-you")
-      })
-      .catch(err => console.error(err))
-  }
-
-  IsomorphicRelay.prepareData({
-    Container: Inquiries,
-    queryConfig: new CurrentUserRoute(),
-  }, res.locals.networkLayer).then(
-    ({data, props}) => {
-      const html = renderToString(<IsomorphicRelay.Renderer {...props} />)
-      const styles = styleSheet.rules().map(rule => rule.cssText).join("\n")
-      res.locals.sharify.data.USER_DATA = req.user.toJSON()
-      res.locals.sharify.data.DATA = data
-      res.send(renderPage({
-        styles,
-        html,
-        entrypoint: req.baseUrl + "/bundles/inquiries.js",
-        sharify: res.locals.sharify.script(),
-        baseURL: req.baseUrl,
-      }))
-    })
-})
+app.get("/inquiries", Inquiries)
 
 export default app

--- a/src/apps/loyalty/server/route_handlers.tsx
+++ b/src/apps/loyalty/server/route_handlers.tsx
@@ -1,5 +1,6 @@
 import * as artsyPassport from "artsy-passport"
 import { NextFunction, Request, Response } from "express"
+import { default as IsomorphicRelay } from "isomorphic-relay"
 import * as React from "react"
 
 import { renderToString } from "react-dom/server"
@@ -8,8 +9,13 @@ import LoginContainer from "../containers/login"
 import { CollectorProfileResponse } from "./gravity"
 import renderPage from "./template"
 
+import CurrentUserRoute from "../../../relay/queries/current_user"
+
 import ThreewThankYou from "../containers/3w_thank_you"
 import AcbThankYou from "../containers/acb_thank_you"
+import InquiriesContainer from "../containers/inquiries"
+
+import { markCollectorAsLoyaltyApplicant } from "./gravity"
 
 export function Home(req: Request, res: Response, next: NextFunction) {
   return res.redirect(req.baseUrl + "/inquiries")
@@ -39,6 +45,44 @@ export function ThankYou(req: Request, res: Response, next: NextFunction) {
 
   const styles = styleSheet.rules().map(rule => rule.cssText).join("\n")
   return res.send(renderPage({ styles, html, entrypoint: "", baseURL: req.baseUrl }))
+}
+
+export function Inquiries(req: Request, res: Response, next: NextFunction) {
+  const { loginPagePath } = artsyPassport.options
+  if (!req.user) {
+    return res.redirect(req.baseUrl + loginPagePath)
+  }
+
+  const info = req.user.get("profile")
+  if (info.loyalty_applicant_at) {
+    return res.redirect(req.baseUrl + "/thank-you")
+  }
+
+  if (info.confirmed_buyer_at) {
+    markCollectorAsLoyaltyApplicant(req.user.get("accessToken"))
+      .then(profile => {
+        return res.redirect(req.baseUrl + "/thank-you")
+      })
+      .catch(err => console.error(err))
+  }
+
+  IsomorphicRelay.prepareData({
+    Container: InquiriesContainer,
+    queryConfig: new CurrentUserRoute(),
+  }, res.locals.networkLayer).then(
+    ({data, props}) => {
+      const html = renderToString(<IsomorphicRelay.Renderer {...props} />)
+      const styles = styleSheet.rules().map(rule => rule.cssText).join("\n")
+      res.locals.sharify.data.USER_DATA = req.user.toJSON()
+      res.locals.sharify.data.DATA = data
+      res.send(renderPage({
+        styles,
+        html,
+        entrypoint: req.baseUrl + "/bundles/inquiries.js",
+        sharify: res.locals.sharify.script(),
+        baseURL: req.baseUrl,
+      }))
+    })
 }
 
 export function Login(req: Request, res: Response, next: NextFunction) {

--- a/src/apps/loyalty/server/route_handlers.tsx
+++ b/src/apps/loyalty/server/route_handlers.tsx
@@ -75,7 +75,7 @@ export function Inquiries(req: Request, res: Response, next: NextFunction) {
       const styles = styleSheet.rules().map(rule => rule.cssText).join("\n")
       res.locals.sharify.data.USER_DATA = req.user.toJSON()
       res.locals.sharify.data.DATA = data
-      res.send(renderPage({
+      return res.send(renderPage({
         styles,
         html,
         entrypoint: req.baseUrl + "/bundles/inquiries.js",


### PR DESCRIPTION
Building on yesterday's snapshot tests, this moves the last route handler for inquiries out of the server index file, adds a snapshot test, and a couple more small tests (+ one about not rendering inquiries that lack an impulse conversation).

