### PR TITLE
[Loyalty QA] center log in button text in safari

### DIFF
--- a/src/apps/loyalty/containers/3w_thank_you/__tests__/__snapshots__/index.ts.snap
+++ b/src/apps/loyalty/containers/3w_thank_you/__tests__/__snapshots__/index.ts.snap
@@ -42,7 +42,7 @@ exports[`3-way Handshake Thank You renders the snapshot 1`] = `
   <div
     className="ChQBa">
     <a
-      className="hAmmpZ"
+      className="gwPnRz"
       href="/">
       <span>
         Back to Artsy

--- a/src/apps/loyalty/containers/acb_thank_you/__tests__/__snapshots__/index.ts.snap
+++ b/src/apps/loyalty/containers/acb_thank_you/__tests__/__snapshots__/index.ts.snap
@@ -45,7 +45,7 @@ exports[`ACB Thank You renders the snapshot 1`] = `
   <div
     className="jzLjyo">
     <a
-      className="hAmmpZ"
+      className="gwPnRz"
       href="/">
       <span>
         Back to Artsy

--- a/src/apps/loyalty/containers/login/__tests__/__snapshots__/index.tsx.snap
+++ b/src/apps/loyalty/containers/login/__tests__/__snapshots__/index.tsx.snap
@@ -30,12 +30,7 @@ exports[`login renders the snapshot 1`] = `
       type="hidden"
       value="csrf" />
     <button
-      className="jkaRYz"
-      style={
-        Object {
-          "flexDirection": "column",
-        }
-      }>
+      className="dLWLJv">
       <span>
         Log In
       </span>
@@ -49,7 +44,7 @@ exports[`login renders the snapshot 1`] = `
       or
     </div>
     <a
-      className="OZEVy hUOVI"
+      className="dzvQZu eYaNZQ"
       href="/facebook"
       icon={
         <Styled(Icon)
@@ -66,7 +61,7 @@ exports[`login renders the snapshot 1`] = `
       </span>
     </a>
     <a
-      className="iuQEPI hUOVI"
+      className="eTVvmy eYaNZQ"
       href="/twitter"
       icon={
         <Styled(Icon)

--- a/src/apps/loyalty/containers/login/__tests__/__snapshots__/index.tsx.snap
+++ b/src/apps/loyalty/containers/login/__tests__/__snapshots__/index.tsx.snap
@@ -30,7 +30,12 @@ exports[`login renders the snapshot 1`] = `
       type="hidden"
       value="csrf" />
     <button
-      className="jkaRYz">
+      className="jkaRYz"
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }>
       <span>
         Log In
       </span>

--- a/src/apps/loyalty/containers/login/index.tsx
+++ b/src/apps/loyalty/containers/login/index.tsx
@@ -53,7 +53,7 @@ class Login extends React.Component<LoginProps, LoginState> {
 
           {form.csrfToken && <input type="hidden" name="_csrf" value={form.csrfToken} />}
 
-          <Button block>Log In</Button>
+          <Button block style={{flexDirection: "column"}}>Log In</Button>
           <div style={{textAlign: "center"}}>or</div>
           <FacebookButton href={form.facebookPath} block />
           <TwitterButton href={form.twitterPath} block />

--- a/src/apps/loyalty/containers/login/index.tsx
+++ b/src/apps/loyalty/containers/login/index.tsx
@@ -53,7 +53,7 @@ class Login extends React.Component<LoginProps, LoginState> {
 
           {form.csrfToken && <input type="hidden" name="_csrf" value={form.csrfToken} />}
 
-          <Button block style={{flexDirection: "column"}}>Log In</Button>
+          <Button block>Log In</Button>
           <div style={{textAlign: "center"}}>or</div>
           <FacebookButton href={form.facebookPath} block />
           <TwitterButton href={form.twitterPath} block />

--- a/src/components/buttons/default.tsx
+++ b/src/components/buttons/default.tsx
@@ -54,6 +54,7 @@ export const StyledButton = styled(Button)`
     return "black"
   }};
   display: inline-flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   padding: 15px 30px;

--- a/src/components/buttons/facebook.tsx
+++ b/src/components/buttons/facebook.tsx
@@ -16,6 +16,7 @@ export default styled(FacebookButton)`
   height: 40px;
   padding: 0 30px;
   margin: 10px auto 2px;
+  flex-direction: row;
 
   &:hover:not(:disabled) {
     background: #252C68;

--- a/src/components/buttons/twitter.tsx
+++ b/src/components/buttons/twitter.tsx
@@ -16,6 +16,7 @@ export default styled(TwitterButton)`
   height: 40px;
   padding: 0 30px;
   margin: 5px auto 5px;
+  flex-direction: row;
 
   &:hover:not(:disabled) {
     background: #0D73B6;


### PR DESCRIPTION
closes: https://github.com/artsy/reaction-force/issues/103

By default, the `flex-direction` property is set to `row` which aligns the flex-items along the main (x) axis. It looks like that is what's causing the "LOG IN" text to sit to the left. I think we want to style it to have`flex-direction: column` in this case. 

![screen shot 2017-04-18 at 1 12 47 pm](https://cloud.githubusercontent.com/assets/5201004/25143519/c560e07c-2438-11e7-9a9b-cc9339e10bf9.png)
