### PR TITLE
@l2succes => Repeat Visitor page

### DIFF
--- a/src/apps/loyalty/__tests__/server.tsx
+++ b/src/apps/loyalty/__tests__/server.tsx
@@ -1,4 +1,5 @@
-import { Home, ThankYou, ThankYouHtml } from "../server/route_handlers"
+import { ThankYouHtml } from "../server/helpers"
+import { Home, ThankYou } from "../server/route_handlers"
 
 describe ("Home page", () => {
   it("redirects to /inquiries", () => {

--- a/src/apps/loyalty/__tests__/server.tsx
+++ b/src/apps/loyalty/__tests__/server.tsx
@@ -13,8 +13,12 @@ describe ("Home page", () => {
 describe("ThankYouHTML", () => {
   it("renders the acb template for confirmed buyers", () => {
     let profile = { confirmed_buyer_at: "trust me im a buyer" } as any
-    let html = ThankYouHtml(profile)
+    let html = ThankYouHtml(profile, null, true)
     expect(html).toMatch("EARLY ACCESS")
+  })
+  it("renders the repeat visitor template when revisiting the page", () => {
+    let html = ThankYouHtml({} as any, null, false)
+    expect(html).toMatch("Your purchases are being reviewed")
   })
 })
 

--- a/src/apps/loyalty/containers/inquiries/index.tsx
+++ b/src/apps/loyalty/containers/inquiries/index.tsx
@@ -115,7 +115,7 @@ export class Inquiries extends React.Component<RelayProps, State> {
       onFailure: this.onSubmitUpdatesFailed,
       onSuccess: response => {
         if (response.updateCollectorProfile.loyalty_applicant_at) {
-          window.location.pathname = "/loyalty/thank-you"
+          window.location.href = "/loyalty/thank-you?recent_applicant=true"
         }
       },
     })

--- a/src/apps/loyalty/containers/repeat_visitor/__tests__/__snapshots__/index.ts.snap
+++ b/src/apps/loyalty/containers/repeat_visitor/__tests__/__snapshots__/index.ts.snap
@@ -1,0 +1,44 @@
+exports[`RepeatVisitor renders the snapshot 1`] = `
+<div
+  className="jBvxsI">
+  <div
+    className="hiqXMD">
+    <div
+      className="dHhWkf">
+      <div
+        className="gQelpA"
+        style={undefined}>
+        
+      </div>
+    </div>
+    <a
+      className="iDuDUI"
+      href="/">
+      Back To Artsy
+    </a>
+  </div>
+  <div
+    className="dvtHsH">
+    Your purchases are being reviewed
+  </div>
+  <div
+    className="ChQBa">
+    <p
+      className="fTgPgI">
+      We will be in touch once we confirm your
+      <br />
+      purchases with the galleries.
+    </p>
+  </div>
+  <div
+    className="ChQBa">
+    <a
+      className="gwPnRz"
+      href="/">
+      <span>
+        Back to Artsy
+      </span>
+    </a>
+  </div>
+</div>
+`;

--- a/src/apps/loyalty/containers/repeat_visitor/__tests__/index.ts
+++ b/src/apps/loyalty/containers/repeat_visitor/__tests__/index.ts
@@ -1,0 +1,19 @@
+import * as React from "react"
+import * as ReactTestUtils from "react-dom/test-utils"
+import * as renderer from "react-test-renderer"
+
+import RepeatVisitor from "../index"
+
+describe("RepeatVisitor", () => {
+  it("renders the snapshot", () => {
+    const repeatVisitor = renderer.create(RepeatVisitor({}))
+    expect(repeatVisitor).toMatchSnapshot()
+  })
+
+  it("renders the correct content", () => {
+    const repeatVisitor = ReactTestUtils.renderIntoDocument(RepeatVisitor({}))
+    const divTags = ReactTestUtils.scryRenderedDOMComponentsWithTag(repeatVisitor, "div")
+    const titleTag = divTags.find(tag => tag.textContent === "Your purchases are being reviewed")
+    expect(titleTag).toBeTruthy()
+  })
+})

--- a/src/apps/loyalty/containers/repeat_visitor/index.tsx
+++ b/src/apps/loyalty/containers/repeat_visitor/index.tsx
@@ -1,0 +1,43 @@
+import * as React from "react"
+import styled from "styled-components"
+
+import colors from "../../../../assets/colors"
+
+import Button from "../../../../components/buttons/inverted"
+import Nav from "../../../../components/nav"
+import NavItem from "../../../../components/nav_item"
+import Text from "../../../../components/text"
+import Title from "../../../../components/title"
+
+const Container = styled.div`
+  text-align: center;
+`
+
+const Section = styled.div`
+  marginTop: 40px;
+`
+
+const ButtonWrapper = styled.div`
+  marginTop: 40px;
+`
+
+export default props => (
+  <Container>
+    <Nav>
+      <NavItem href="/">Back To Artsy</NavItem>
+    </Nav>
+
+    <Title>Your purchases are being reviewed</Title>
+
+    <Section>
+      <Text textSize="large" align="center">
+        We will be in touch once we confirm your<br />
+        purchases with the galleries.
+      </Text>
+    </Section>
+
+    <ButtonWrapper>
+      <Button href="/">Back to Artsy</Button>
+    </ButtonWrapper>
+  </Container>
+)

--- a/src/apps/loyalty/server/helpers.tsx
+++ b/src/apps/loyalty/server/helpers.tsx
@@ -1,0 +1,17 @@
+import * as React from "react"
+
+import { renderToString } from "react-dom/server"
+import ThreewThankYou from "../containers/3w_thank_you"
+import AcbThankYou from "../containers/acb_thank_you"
+import RepeatVisitor from "../containers/repeat_visitor"
+import { CollectorProfileResponse } from "./gravity"
+
+export function ThankYouHtml(info: CollectorProfileResponse, userName?: string, recentApplicant?: boolean): string {
+  if (recentApplicant) {
+    if (info.confirmed_buyer_at) {
+      return renderToString(<AcbThankYou />)
+    }
+    return renderToString(<ThreewThankYou userName={userName} />)
+  }
+  return renderToString(<RepeatVisitor />)
+}

--- a/src/apps/loyalty/server/route_handlers.tsx
+++ b/src/apps/loyalty/server/route_handlers.tsx
@@ -11,25 +11,13 @@ import renderPage from "./template"
 
 import CurrentUserRoute from "../../../relay/queries/current_user"
 
-import ThreewThankYou from "../containers/3w_thank_you"
-import AcbThankYou from "../containers/acb_thank_you"
 import InquiriesContainer from "../containers/inquiries"
-import RepeatVisitor from "../containers/repeat_visitor"
 
 import { markCollectorAsLoyaltyApplicant } from "./gravity"
+import { ThankYouHtml } from "./helpers"
 
 export function Home(req: Request, res: Response, next: NextFunction) {
   return res.redirect(req.baseUrl + "/inquiries")
-}
-
-export function ThankYouHtml(info: CollectorProfileResponse, userName?: string, recentApplicant?: boolean): string {
-  if (recentApplicant) {
-    if (info.confirmed_buyer_at) {
-      return renderToString(<AcbThankYou />)
-    }
-    return renderToString(<ThreewThankYou userName={userName} />)
-  }
-  return renderToString(<RepeatVisitor />)
 }
 
 export function ThankYou(req: Request, res: Response, next: NextFunction) {

--- a/src/apps/loyalty/server/route_handlers.tsx
+++ b/src/apps/loyalty/server/route_handlers.tsx
@@ -14,6 +14,7 @@ import CurrentUserRoute from "../../../relay/queries/current_user"
 import ThreewThankYou from "../containers/3w_thank_you"
 import AcbThankYou from "../containers/acb_thank_you"
 import InquiriesContainer from "../containers/inquiries"
+import RepeatVisitor from "../containers/repeat_visitor"
 
 import { markCollectorAsLoyaltyApplicant } from "./gravity"
 
@@ -21,11 +22,14 @@ export function Home(req: Request, res: Response, next: NextFunction) {
   return res.redirect(req.baseUrl + "/inquiries")
 }
 
-export function ThankYouHtml(info: CollectorProfileResponse, userName?: string): string {
-  if (info.confirmed_buyer_at) {
-    return renderToString(<AcbThankYou />)
+export function ThankYouHtml(info: CollectorProfileResponse, userName?: string, recentApplicant?: boolean): string {
+  if (recentApplicant) {
+    if (info.confirmed_buyer_at) {
+      return renderToString(<AcbThankYou />)
+    }
+    return renderToString(<ThreewThankYou userName={userName} />)
   }
-  return renderToString(<ThreewThankYou userName={userName} />)
+  return renderToString(<RepeatVisitor />)
 }
 
 export function ThankYou(req: Request, res: Response, next: NextFunction) {
@@ -38,7 +42,7 @@ export function ThankYou(req: Request, res: Response, next: NextFunction) {
   let html
 
   if (info.loyalty_applicant_at) {
-    html = ThankYouHtml(info, req.user.attributes.name)
+    html = ThankYouHtml(info, req.user.attributes.name, req.query.recent_applicant)
   } else {
     return res.redirect(req.baseUrl) // baseUrl already has "/loyalty" so no need to append it.
   }


### PR DESCRIPTION
Adds the repeat visitor page.

Since I think we'd just want this at `/thank-you`, but we do full server-side reloads/redirects, there's no way of knowing if someone visits `/thank-you` b/c they just submitted their application, or it's a repeat visit.

So we just use a query param to indicate they just submitted the form. Since `/thank-you` will redirect you back to `/inquiries` if you aren't actually a registered applicant, I think it's fine to rely on the query param. What do you think?

<img width="645" alt="screen shot 2017-04-19 at 10 41 00 am" src="https://cloud.githubusercontent.com/assets/1457859/25186016/e6f933c4-24ec-11e7-9a99-4afd69812d0c.png">
