### PR TITLE
TextLink shouldn't have any specific font sizes

### DIFF
--- a/src/apps/loyalty/containers/3w_thank_you/__tests__/__snapshots__/index.ts.snap
+++ b/src/apps/loyalty/containers/3w_thank_you/__tests__/__snapshots__/index.ts.snap
@@ -33,7 +33,7 @@ exports[`3-way Handshake Thank You renders the snapshot 1`] = `
       <br />
       Have questions? Get in touch:  
       <a
-        className="ickHKL"
+        className="hNDkSz"
         href="mailto:loyalty@artsy.net">
         loyalty@artsy.net
       </a>

--- a/src/apps/loyalty/containers/acb_thank_you/__tests__/__snapshots__/index.ts.snap
+++ b/src/apps/loyalty/containers/acb_thank_you/__tests__/__snapshots__/index.ts.snap
@@ -36,7 +36,7 @@ exports[`ACB Thank You renders the snapshot 1`] = `
       <br />
       Have questions? Get in touch:  
       <a
-        className="ickHKL"
+        className="hNDkSz"
         href="mailto:loyalty@artsy.net">
         loyalty@artsy.net
       </a>

--- a/src/apps/loyalty/containers/inquiries/__tests__/__snapshots__/index.tsx.snap
+++ b/src/apps/loyalty/containers/inquiries/__tests__/__snapshots__/index.tsx.snap
@@ -71,14 +71,14 @@ exports[`inquiries renders the inquiries listing 1`] = `
                   <div>
                     <strong>
                       <a
-                        className="jehOuL"
+                        className="cXjeFh"
                         href="/percy-z">
                         Percy Z
                       </a>
                     </strong>
                   </div>
                   <a
-                    className="jehOuL"
+                    className="cXjeFh"
                     href={undefined}>
                     <em />
                   </a>

--- a/src/apps/loyalty/containers/login/__tests__/__snapshots__/index.tsx.snap
+++ b/src/apps/loyalty/containers/login/__tests__/__snapshots__/index.tsx.snap
@@ -85,7 +85,7 @@ exports[`login renders the snapshot 1`] = `
       Don\'t have an account? 
     </span>
     <a
-      className="kfGluK"
+      className="lkuLzT"
       href={undefined}>
       Sign up
     </a>

--- a/src/components/__tests__/__snapshots__/artwork.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/artwork.test.tsx.snap
@@ -19,14 +19,14 @@ exports[`Artwork renders correctly 1`] = `
       <div>
         <strong>
           <a
-            className="jehOuL"
+            className="cXjeFh"
             href={undefined}>
             Mikael Olson
           </a>
         </strong>
       </div>
       <a
-        className="jehOuL"
+        className="cXjeFh"
         href="/artwork/mikael-olson-some-kind-of-dinosaur">
         <em>
           Some Kind of Dinosaur
@@ -35,7 +35,7 @@ exports[`Artwork renders correctly 1`] = `
       </a>
       <div>
         <a
-          className="jehOuL"
+          className="cXjeFh"
           href={undefined}>
           Gallery 1261
         </a>

--- a/src/components/text_link.tsx
+++ b/src/components/text_link.tsx
@@ -22,7 +22,6 @@ export class TextLink extends React.Component<LinkProps, null> {
 }
 
 const StyledTextLink = styled(TextLink)`
-  font-size: 15px;
   color: ${props => props.color};
   text-decoration: ${props => props.underline ? "underline" : "none"}
 `


### PR DESCRIPTION
This addresses the font size for the email link on the thank you page: https://github.com/artsy/collector-experience/issues/228
This change doesn't affect any links in the Artwork grid.

## Before

<img width="418" alt="screen shot 2017-04-19 at 11 54 57" src="https://cloud.githubusercontent.com/assets/386234/25189429/1fa521ba-24f7-11e7-9b87-dfa4e7846801.png">

## After

<img width="447" alt="screen shot 2017-04-19 at 11 55 08" src="https://cloud.githubusercontent.com/assets/386234/25189436/23575314-24f7-11e7-938f-c49b479a039f.png">
