### PR TITLE
@l2succes => Loyalty Applicant submission tracking

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ app.use(sharify)
 // Inject METAPHYSICS_ENDPOINT to sharify data
 // Todo/Enhancement: inject any 'safe ENV vars?
 sharify.data.METAPHYSICS_ENDPOINT = process.env.METAPHYSICS_ENDPOINT
+sharify.data.SEGMENT_WRITE_KEY =  process.env.SEGMENT_WRITE_KEY
 app.use(cookieParser())
 app.use(session({
   secret: "secret",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/react-dom": "^15.5.0",
     "@types/react-relay": "^0.9.12",
     "@types/react-test-renderer": "^15.4.4",
+    "@types/segment-analytics": "^0.0.27",
     "awesome-typescript-loader": "^3.1.2",
     "babel-core": "^6.24.0",
     "babel-plugin-react-relay": "^0.10.0",

--- a/src/apps/loyalty/server/route_handlers.tsx
+++ b/src/apps/loyalty/server/route_handlers.tsx
@@ -71,7 +71,7 @@ export function Inquiries(req: Request, res: Response, next: NextFunction) {
         styles,
         html,
         entrypoint: req.baseUrl + "/bundles/inquiries.js",
-        sharify: res.locals.sharify.script(),
+        sharify: res.locals.sharify,
         baseURL: req.baseUrl,
       }))
     })
@@ -97,7 +97,7 @@ export function Login(req: Request, res: Response, next: NextFunction) {
     styles,
     html,
     entrypoint: req.baseUrl + "/bundles/login.js",
-    sharify: res.locals.sharify.script(),
+    sharify: res.locals.sharify,
     baseURL: req.baseUrl,
   }))
 }

--- a/src/apps/loyalty/server/route_handlers.tsx
+++ b/src/apps/loyalty/server/route_handlers.tsx
@@ -36,7 +36,7 @@ export function ThankYou(req: Request, res: Response, next: NextFunction) {
   }
 
   const styles = styleSheet.rules().map(rule => rule.cssText).join("\n")
-  return res.send(renderPage({ styles, html, entrypoint: "", baseURL: req.baseUrl }))
+  return res.send(renderPage({ styles, html, entrypoint: "", baseURL: req.baseUrl, sharify: res.locals.sharify }))
 }
 
 export function Inquiries(req: Request, res: Response, next: NextFunction) {

--- a/src/apps/loyalty/server/template.tsx
+++ b/src/apps/loyalty/server/template.tsx
@@ -3,13 +3,20 @@ interface TemplateData {
   html: string
   entrypoint: string
   bootstrapData?: string
-  sharify?: string
+  sharify?: any
   baseURL: string
 }
 
 export default ({styles, html, entrypoint, bootstrapData, sharify, baseURL}: TemplateData) => {
   const fontsURL = "//fast.fonts.net/cssapi/f7f47a40-b25b-44ee-9f9c-cfdfc8bb2741.css"
-
+  const segmentWriteKey = sharify.data.SEGMENT_WRITE_KEY
+  /* tslint:disable:max-line-length */
+  const segmentJS = `
+  !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.0.1";
+  analytics.load("${segmentWriteKey}");
+  }}();
+  `
+  /* tslint:enable:max-line-length */
   return `
       <html>
         <head>
@@ -18,10 +25,11 @@ export default ({styles, html, entrypoint, bootstrapData, sharify, baseURL}: Tem
           <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
           <style>#app-container { width: 100%; overflow: hidden;  }</style>
           <style>${styles}</style>
+          <script type="text/javascript">${segmentJS}</script>
         </head>
         <body>
           <div id="app-container">${html}</div>
-          ${sharify ? sharify : ""}
+          ${sharify.script()}
           ${bootstrapData ? "<script>" + bootstrapData + "</script>" : ""}
           <script src="${baseURL}/bundles/commons.chunk.js"></script>
           <script src="${entrypoint}"></script>

--- a/src/apps/loyalty/server/template.tsx
+++ b/src/apps/loyalty/server/template.tsx
@@ -29,7 +29,7 @@ export default ({styles, html, entrypoint, bootstrapData, sharify, baseURL}: Tem
         </head>
         <body>
           <div id="app-container">${html}</div>
-          ${sharify.script()}
+          ${sharify ? sharify.script() : ""}
           ${bootstrapData ? "<script>" + bootstrapData + "</script>" : ""}
           <script src="${baseURL}/bundles/commons.chunk.js"></script>
           <script src="${entrypoint}"></script>

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="segment-analytics" />
+
+interface Window {
+  analytics: SegmentAnalytics.AnalyticsJS
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -217,6 +217,10 @@
   version "15.0.21"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.21.tgz#29d849427237c1463abfb7b370755ee3e5b5b375"
 
+"@types/segment-analytics@^0.0.27":
+  version "0.0.27"
+  resolved "https://registry.yarnpkg.com/@types/segment-analytics/-/segment-analytics-0.0.27.tgz#158b7b37c1aa4fab7f9d6f1c91c95c49ac8fac58"
+
 "@types/serve-static@*":
   version "1.7.31"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.7.31.tgz#15456de8d98d6b4cff31be6c6af7492ae63f521a"


### PR DESCRIPTION
~~Just a little thing to start...this basically loads the segment JS and passes in our key thru sharify.~~

~~This does work in the browser JS console...now to try to actually use it in the react code.~~

This adds the segment JS into the inquiries template, and also directly tracks the successful loyalty submission with the required props.

I did a tiny refactor to the state to just store an array of the selected conversations.