### PR TITLE
Fixes CircleCI auto publish

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,4 +22,5 @@ deployment:
   npm:
     tag: /v[0-9]+(\.[0-9]+)*/
     commands:
+      - npm prepublishOnly
       - npm publish

--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "repository": "https://github.com/artsy/reaction-force.git",
   "author": "Eloy Durán <eloy.de.enige@gmail.com>",
   "license": "MIT",
+  "files": [
+    "dist",
+    "assets",
+    "data",
+    "docs"
+  ],
   "scripts": {
     "start": "node verify-node-version.js && ts-babel-node index.js",
     "start:dist": "npm run compile && node index.js ./dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/reaction-force",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Force’s React Components",
   "main": "dist/index.js",
   "repository": "https://github.com/artsy/reaction-force.git",


### PR DESCRIPTION
The `npm prepublishOnly` hook is not being run on circle CI because the version of npm is outdated so it has to be triggered manually

https://github.com/travis-ci/travis-ci/issues/6953