### PR TITLE
@l2succes => Use metaphysics url from ENV rather than hard-coded value

### DIFF
--- a/src/relay/config.ts
+++ b/src/relay/config.ts
@@ -1,10 +1,8 @@
 import * as Relay from "react-relay"
 const sharify = require("sharify")
 
-export const metaphysicsURL = "https://metaphysics-production.artsy.net"
-
 export function artsyNetworkLayer(user?: any) {
-  return new Relay.DefaultNetworkLayer(metaphysicsURL, {
+  return new Relay.DefaultNetworkLayer(sharify.data.METAPHYSICS_ENDPOINT, {
     headers: !!user ? {
       "X-USER-ID": user.id,
       "X-ACCESS-TOKEN": user.accessToken,


### PR DESCRIPTION
Re-adds the metaphysics ref from sharify vs hard-coded value.