### PR TITLE
@alloy => Use Segment's node lib for analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@kadira/storybook": "^2.35.3",
     "@kadira/storybook-addons": "^1.6.1",
     "@kadira/storybook-deployer": "^1.2.0",
+    "@types/analytics-node": "^0.0.30",
     "@types/backbone": "^1.3.33",
     "@types/body-parser": "^1.16.1",
     "@types/cookie-parser": "^1.3.30",
@@ -50,6 +51,7 @@
     "@types/react-relay": "^0.9.12",
     "@types/react-test-renderer": "^15.4.4",
     "@types/segment-analytics": "^0.0.27",
+    "@types/uuid": "^2.0.29",
     "awesome-typescript-loader": "^3.1.2",
     "babel-core": "^6.24.0",
     "babel-plugin-react-relay": "^0.10.0",
@@ -93,6 +95,7 @@
     "webpack-stream": "^3.2.0"
   },
   "dependencies": {
+    "analytics-node": "^2.4.0",
     "artsy-passport": "^1.6.1",
     "artsy-xapp": "^1.0.4",
     "babel-polyfill": "^6.23.0",
@@ -112,7 +115,8 @@
     "react-styled-flexboxgrid": "^1.0.2",
     "request": "^2.81.0",
     "sharify": "^0.1.6",
-    "styled-components": "^1.4.3"
+    "styled-components": "^1.4.3",
+    "uuid": "^3.0.1"
   },
   "graphql": {
     "file": "data/schema.json",

--- a/src/apps/loyalty/analytics.ts
+++ b/src/apps/loyalty/analytics.ts
@@ -1,0 +1,79 @@
+import { extend, pick } from "lodash"
+import * as sharify from "sharify"
+
+import { ResponseLocalData } from "./types"
+const data = sharify.data as ResponseLocalData
+
+const Analytics = require("analytics-node")
+
+let analytics
+if (data.SEGMENT_WRITE_KEY) {
+  analytics = new Analytics(data.SEGMENT_WRITE_KEY, { flushAt: 1 })
+}
+
+export function initAnalytics() {
+  Identify()
+  Pageview()
+  FifteenSecondBounceRate()
+  ThreeMinuteBounceRate()
+}
+
+export function TrackSubmission(properties: Object) {
+  if (data.CURRENT_USER) {
+    const options = {
+      userId: data.CURRENT_USER.id,
+      event: "Submitted loyalty purchases",
+      properties,
+    }
+    analytics.track(options)
+  }
+}
+
+function Identify() {
+  if (data.CURRENT_USER) {
+    let whitelist = ["collector_level", "default_profile_id", "email", "id", "name", "phone", "type"]
+    let traits = extend(pick(data.CURRENT_USER, whitelist), { session_id: data.SESSION_ID })
+
+    const options = {
+      userId: data.CURRENT_USER.id,
+      traits,
+      integrations: { Marketo: false },
+    }
+
+    analytics.identify(options)
+  }
+}
+
+function FifteenSecondBounceRate() {
+  const options = {
+    userId: data.CURRENT_USER.id,
+    event: "time on page more than 15 seconds",
+    category: "15 seconds",
+    message: location.pathname,
+  }
+  setTimeout(() => {
+    analytics.track(options)
+  }, 15000)
+}
+
+function ThreeMinuteBounceRate() {
+  const options = {
+    userId: data.CURRENT_USER.id,
+    event: "time on page more than 15 seconds",
+    category: "15 seconds",
+    message: location.pathname,
+  }
+  setTimeout(() => {
+    analytics.track(options)
+  }, 180000)
+}
+
+function Pageview() {
+  if (data.CURRENT_USER) {
+    const options = {
+      userId: data.CURRENT_USER.id,
+      integrations: { Marketo: false },
+    }
+    analytics.page(options)
+  }
+}

--- a/src/apps/loyalty/containers/forgot_password/browser.tsx
+++ b/src/apps/loyalty/containers/forgot_password/browser.tsx
@@ -5,6 +5,9 @@ import ForgotPassword from "./index"
 const submitUrl = require("sharify").data.SUBMIT_URL
 const appToken = require("sharify").data.APP_TOKEN
 
+import { initAnalytics } from "../../analytics"
+
+initAnalytics()
 render(
   <ForgotPassword submitEmailUrl={submitUrl} appToken={appToken} />,
   document.getElementById("app-container"),

--- a/src/apps/loyalty/containers/inquiries/browser.tsx
+++ b/src/apps/loyalty/containers/inquiries/browser.tsx
@@ -12,6 +12,8 @@ import { ResponseLocalData } from "../../types"
 
 import * as Artsy from "../../../../components/artsy"
 
+import { initAnalytics } from "../../analytics"
+
 const { CURRENT_USER, RELAY_DATA } = sharify.data as ResponseLocalData
 
 const env = new (Relay as any).Environment()
@@ -27,6 +29,7 @@ IsomorphicRelay.prepareInitialRender({
   queryConfig: new CurrentUserRoute(),
   environment: env,
 }).then(props => {
+  initAnalytics()
   render(
     (
       <Artsy.ContextProvider currentUser={CURRENT_USER}>

--- a/src/apps/loyalty/containers/inquiries/index.tsx
+++ b/src/apps/loyalty/containers/inquiries/index.tsx
@@ -19,6 +19,8 @@ import * as Artsy from "../../../../components/artsy"
 import UpdateCollectorProfileMutation from "./mutations/update_collector_profile"
 import UpdateConversationMutation from "./mutations/update_conversation"
 
+import { TrackSubmission } from "../../analytics"
+
 const InquiryContainer = styled.div`
   margin-bottom: 60px;
   width: 100%;
@@ -185,7 +187,7 @@ export class Inquiries extends React.Component<Props, State> {
       additional_response: this.state.self_reported_purchases,
       purchase_count: ids.length,
     }
-    window.analytics.track("Submitted loyalty purchases", props)
+    TrackSubmission(props)
   }
 
   enableSubmitButton() {

--- a/src/apps/loyalty/containers/inquiries/index.tsx
+++ b/src/apps/loyalty/containers/inquiries/index.tsx
@@ -181,7 +181,7 @@ export class Inquiries extends React.Component<Props, State> {
 
     const props = {
       user_id: this.props.currentUser.id,
-      inquiry_ids: ids,
+      impulse_conversation_ids: ids,
       additional_response: this.state.self_reported_purchases,
       purchase_count: ids.length,
     }

--- a/src/apps/loyalty/server/index.tsx
+++ b/src/apps/loyalty/server/index.tsx
@@ -4,6 +4,7 @@ import * as express from "express"
 import * as path from "path"
 
 import RelayMiddleware from "./middlewares/relay"
+import SetSessionMiddleware from "./middlewares/session"
 import UserMiddleware from "./middlewares/user"
 import { ForgotPassword, Home, Inquiries, Login, ThankYou } from "./route_handlers"
 
@@ -23,6 +24,7 @@ app.use(artsyPassport(Object.assign({
 
 app.use(RelayMiddleware)
 app.use(UserMiddleware)
+app.use(SetSessionMiddleware)
 
 app.get("/", Home)
 app.get(loginPagePath, Login)

--- a/src/apps/loyalty/server/middlewares/session.ts
+++ b/src/apps/loyalty/server/middlewares/session.ts
@@ -1,0 +1,11 @@
+import { NextFunction, Request, Response } from "express"
+import * as uuid from "uuid"
+
+export default function SetSessionMiddleware(req: Request, res: Response, next: NextFunction) {
+  if (req.sessionID) {
+    res.locals.sharify.data.SESSION_ID = req.sessionID
+  } else {
+    res.locals.sharify.data.SESSION_ID = uuid.v1()
+  }
+  next()
+}

--- a/src/apps/loyalty/server/template.tsx
+++ b/src/apps/loyalty/server/template.tsx
@@ -11,14 +11,6 @@ interface TemplateData {
 
 export default ({ styles, html, entrypoint, bootstrapData, sharify, baseURL }: TemplateData) => {
   const fontsURL = "//fast.fonts.net/cssapi/f7f47a40-b25b-44ee-9f9c-cfdfc8bb2741.css"
-  const segmentWriteKey = sharify.data.SEGMENT_WRITE_KEY
-  /* tslint:disable:max-line-length */
-  const segmentJS = `
-  !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.0.1";
-  analytics.load("${segmentWriteKey}");
-  }}();
-  `
-  /* tslint:enable:max-line-length */
   return `
       <html>
         <head>
@@ -27,7 +19,6 @@ export default ({ styles, html, entrypoint, bootstrapData, sharify, baseURL }: T
           <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
           <style>#app-container { width: 100%; overflow: hidden;  }</style>
           <style>${styles}</style>
-          <script type="text/javascript">${segmentJS}</script>
         </head>
         <body>
           <div id="app-container">${html}</div>

--- a/src/typings/sharify.d.ts
+++ b/src/typings/sharify.d.ts
@@ -24,6 +24,7 @@ declare module "sharify" {
       RELAY_DATA?: any
       SUBMIT_URL?: string
       APP_TOKEN?: string
+      SESSION_ID?: string
     }
 
     export interface ResponseLocal {

--- a/yarn.lock
+++ b/yarn.lock
@@ -120,6 +120,10 @@
     component-type "^1.2.1"
     join-component "^1.1.0"
 
+"@types/analytics-node@^0.0.30":
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/@types/analytics-node/-/analytics-node-0.0.30.tgz#8d9dfc7f7c2fe2344e825d2acc5061c442067229"
+
 "@types/backbone@^1.3.33":
   version "1.3.33"
   resolved "https://registry.yarnpkg.com/@types/backbone/-/backbone-1.3.33.tgz#33ab2e71619dd1d5adc477b689292fee7a34d4a3"
@@ -255,6 +259,12 @@
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.8.0.tgz#7a22ef584d6fe59af2e407bae079e2b7f8a5102f"
 
+"@types/uuid@^2.0.29":
+  version "2.0.29"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-2.0.29.tgz#939a198ab73567f811ab84f670d2be9c25addd41"
+  dependencies:
+    "@types/node" "*"
+
 abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
@@ -347,7 +357,7 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-analytics-node@^2.1.0:
+analytics-node@^2.1.0, analytics-node@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/analytics-node/-/analytics-node-2.4.0.tgz#5b59174bdadd95c8bd47f31bada5bbe15b1df3b7"
   dependencies:
@@ -7598,7 +7608,7 @@ uuid@^2.0.1, uuid@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.0.0:
+uuid@^3.0.0, uuid@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 


### PR DESCRIPTION
We probably should have went this route originally instead of using the Segment.JS stuff.

I didn't rip that out completely, but wanted to get this up early to see what you think. Based on inspecting the responses being sent, we are correctly tracking the pageview/identify/time on page stuff, as well as the existing loyalty submission one.

I'll make a few comments inline.