### PR TITLE
@alloy => Console warn if a mutation fails

### DIFF
--- a/src/apps/loyalty/containers/inquiries/index.tsx
+++ b/src/apps/loyalty/containers/inquiries/index.tsx
@@ -173,6 +173,7 @@ export class Inquiries extends React.Component<Props, State> {
   }
 
   onSubmitUpdatesFailed(transaction) {
+    console.error(transaction.getError())
     alert("Sorry, there was an error with your submission, please try again")
   }
 


### PR DESCRIPTION
This makes it easier to debug if there's an issue. We had a couple today: staging data out of sync (inquiry to conversation), plus missing ENV vars in production.
 
They were tough to diagnose without having to repro locally, put a `debugger` or breakpoint or something in the error handler (which just pops up a generic warning), and seeing what the specific issue was.

I think this is fine even in production?