### PR TITLE
@alloy - Truncate artwork title with ellipsis 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/reaction-force",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "description": "Force’s React Components",
   "main": "dist/index.js",
   "repository": "https://github.com/artsy/reaction-force.git",

--- a/src/apps/loyalty/containers/inquiries/__tests__/__snapshots__/index.tsx.snap
+++ b/src/apps/loyalty/containers/inquiries/__tests__/__snapshots__/index.tsx.snap
@@ -79,7 +79,7 @@ exports[`inquiries renders the inquiries listing 1`] = `
                     </strong>
                   </div>
                   <a
-                    className="cXjeFh"
+                    className="ihYxRh"
                     href={undefined}>
                     <em />
                   </a>

--- a/src/components/__tests__/__snapshots__/artwork.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/artwork.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`Artwork renders correctly 1`] = `
         </strong>
       </div>
       <a
-        className="cXjeFh"
+        className="ihYxRh"
         href="/artwork/mikael-olson-some-kind-of-dinosaur">
         <em>
           Some Kind of Dinosaur

--- a/src/components/artwork/details.tsx
+++ b/src/components/artwork/details.tsx
@@ -2,11 +2,20 @@ import * as React from "react"
 import * as Relay from "react-relay"
 import TextLink from "../text_link"
 
-export interface DetailsProps extends RelayProps, React.HTMLProps<ArtworkDetails> {
+import styled from "styled-components"
+
+const TruncatedTextLink = styled(TextLink)`
+  display: block;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+`
+
+interface Props extends RelayProps, React.HTMLProps<ArtworkDetails> {
   showSaleLine: boolean
 }
 
-export class ArtworkDetails extends React.Component<DetailsProps, null> {
+export class ArtworkDetails extends React.Component<Props, null> {
   static defaultProps = {
     showSaleLine: true,
   }
@@ -25,17 +34,11 @@ export class ArtworkDetails extends React.Component<DetailsProps, null> {
   }
 
   titleLine() {
-    const titleStyle = {
-      display: "block",
-      textOverflow: "ellipsis",
-      overflow: "hidden",
-      whiteSpace: "nowrap",
-    }
     return (
-      <TextLink href={this.props.artwork.href} style={titleStyle}>
+      <TruncatedTextLink href={this.props.artwork.href}>
         <em>{this.props.artwork.title}</em>
         {this.props.artwork.date && `, ${this.props.artwork.date}`}
-      </TextLink>
+      </TruncatedTextLink>
     )
   }
 

--- a/src/components/artwork/details.tsx
+++ b/src/components/artwork/details.tsx
@@ -25,8 +25,14 @@ export class ArtworkDetails extends React.Component<DetailsProps, null> {
   }
 
   titleLine() {
+    const titleStyle = {
+      display: "block",
+      textOverflow: "ellipsis",
+      overflow: "hidden",
+      whiteSpace: "nowrap",
+    }
     return (
-      <TextLink href={this.props.artwork.href}>
+      <TextLink href={this.props.artwork.href} style={titleStyle}>
         <em>{this.props.artwork.title}</em>
         {this.props.artwork.date && `, ${this.props.artwork.date}`}
       </TextLink>

--- a/src/components/artwork_grid.tsx
+++ b/src/components/artwork_grid.tsx
@@ -99,6 +99,7 @@ export class ArtworkGrid extends React.Component<Props, State> {
 
       const sectionSpecificStyle = {
         flex: 1,
+        minWidth: 0,
         marginRight: (i === this.props.columnCount - 1 ? 0 : this.props.sectionMargin),
       }
 
@@ -126,7 +127,9 @@ ArtworkGrid.defaultProps = {
 }
 
 const StyledGrid = styled(ArtworkGrid)`
-  display: flex
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
 `
 
 const ArtworkFragment = Relay.QL`

--- a/src/components/text_link.tsx
+++ b/src/components/text_link.tsx
@@ -6,7 +6,8 @@ import "../assets/fonts"
 export interface LinkProps extends React.Props<TextLink>, React.HTMLAttributes<TextLink> {
   href?: string
   underline?: boolean
-  color?: string
+  color?: string,
+  style?: any,
 }
 
 export class TextLink extends React.Component<LinkProps, null> {

--- a/src/components/text_link.tsx
+++ b/src/components/text_link.tsx
@@ -7,7 +7,6 @@ export interface LinkProps extends React.Props<TextLink>, React.HTMLAttributes<T
   href?: string
   underline?: boolean
   color?: string,
-  style?: any,
 }
 
 export class TextLink extends React.Component<LinkProps, null> {


### PR DESCRIPTION
Closes #160 

Pro tip: `min-width: 0` is the magic property on a flex container to have `text-overflow` work properly....the more you know.