### PR TITLE
Copy .env file for webpack config for storybook

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,6 +18,7 @@ deployment:
   demo:
     branch: master
     commands:
+      - cp .env.oss .env
       - yarn deploy-storybook
   npm:
     tag: /v[0-9]+(\.[0-9]+)*/


### PR DESCRIPTION
It seems like a `.env` file (used to inject `METAPHYSICS_ENDPOINT` in `.storybook/webpack.config.js`) is missing in CircleCI and we need to copy `.env.oss` to `.env`.