### PR TITLE
Add show feed component for fair filter

### DIFF
--- a/src/components/__stories__/fair_booth.tsx
+++ b/src/components/__stories__/fair_booth.tsx
@@ -3,9 +3,11 @@ import * as React from "react"
 import * as Relay from "react-relay"
 
 import FairBooth from "../fair/booth"
+import ShowFeed from "../fair/feed"
 
 import * as Artsy from "../../components/artsy"
 import { artsyNetworkLayer } from "../../relay/config"
+import FairQueryConfig from "../../relay/queries/fair"
 import ShowQueryConfig from "../../relay/queries/show"
 
 function BoothExample(props: { showID: string }) {
@@ -17,6 +19,15 @@ function BoothExample(props: { showID: string }) {
   )
 }
 
+function FeedExample(props: { fairID: string }) {
+  Relay.injectNetworkLayer(artsyNetworkLayer())
+  return (
+    <Artsy.ContextProvider>
+      <Relay.RootContainer Component={ShowFeed} route={new FairQueryConfig({ fairID: props.fairID })} />
+    </Artsy.ContextProvider>
+  )
+}
+
 storiesOf("Fair", FairBooth)
   .add("Booth", () => {
     return (
@@ -24,6 +35,13 @@ storiesOf("Fair", FairBooth)
         <BoothExample
           showID="sies-plus-hoke-1-sies-plus-hoke-at-art-basel-2017"
         />
+      </div>
+    )
+  })
+  .add("Feed", () => {
+    return (
+      <div>
+        <FeedExample fairID="art-basel-2017" />
       </div>
     )
   })

--- a/src/components/artwork_grid.tsx
+++ b/src/components/artwork_grid.tsx
@@ -20,6 +20,14 @@ interface State {
 export class ArtworkGrid extends React.Component<Props, State> {
   public static defaultProps: Partial<Props>
 
+  constructor(props) {
+    super(props)
+    this.state = {
+      interval: null,
+      loading: false,
+    }
+  }
+
   componentDidMount() {
     if (this.props.onLoadMore) {
       const interval = setInterval( () => { this.maybeLoadMore() }, 150 )
@@ -28,7 +36,9 @@ export class ArtworkGrid extends React.Component<Props, State> {
   }
 
   componentWillUnmount() {
-    clearInterval(this.state.interval)
+    if (this.state.interval) {
+      clearInterval(this.state.interval)
+    }
   }
 
   maybeLoadMore() {

--- a/src/components/fair/booth.tsx
+++ b/src/components/fair/booth.tsx
@@ -136,7 +136,6 @@ export default Relay.createContainer(FairBooth, {
   fragments: {
     show: () => Relay.QL`
       fragment on Show {
-        id
         name
         location {
           display

--- a/src/components/fair/booth.tsx
+++ b/src/components/fair/booth.tsx
@@ -58,7 +58,8 @@ export class FairBooth extends React.Component<Props, State> {
 
     const artworksLeft =  show.counts.artworks - relay.variables.artworksSize
 
-    const loadMoreButton = artworks && artworks.pageInfo.hasNextPage && !loading && (
+    const showLoadMore = artworks && artworks.pageInfo.hasNextPage && !loading
+    const loadMoreButton = showLoadMore && (
       <LoadMoreContainer>
         <LoadMoreButton onClick={this.loadMoreArtworks}>
           See {artworksLeft} more artworks

--- a/src/components/fair/booth.tsx
+++ b/src/components/fair/booth.tsx
@@ -5,6 +5,7 @@ import styled from "styled-components"
 import Artworks from "../artwork_grid"
 import Button from "../buttons/ghost"
 import FollowButton from "../follow"
+import Spinner from "../spinner"
 import Text from "../text"
 
 import * as fonts from "../../assets/fonts"
@@ -58,12 +59,17 @@ export class FairBooth extends React.Component<Props, State> {
 
     const artworksLeft =  show.counts.artworks - relay.variables.artworksSize
 
-    const showLoadMore = artworks && artworks.pageInfo.hasNextPage && !loading
-    const loadMoreButton = showLoadMore && (
+    const showLoadMore = artworks && artworks.pageInfo.hasNextPage
+    const loadMoreContent = loading ? (
+      <Spinner />
+    ) : (
+      <LoadMoreButton onClick={this.loadMoreArtworks}>
+        See {artworksLeft} more artworks
+      </LoadMoreButton>
+    )
+    const loadMore = showLoadMore && (
       <LoadMoreContainer>
-        <LoadMoreButton onClick={this.loadMoreArtworks}>
-          See {artworksLeft} more artworks
-        </LoadMoreButton>
+        {loadMoreContent}
       </LoadMoreContainer>
     )
 
@@ -90,7 +96,7 @@ export class FairBooth extends React.Component<Props, State> {
           columnCount={4}
           itemMargin={40}
         />
-        {loadMoreButton}
+        {loadMore}
       </div>
     )
   }
@@ -107,6 +113,8 @@ const LoadMoreContainer = styled.div`
   justify-content: center;
   align-items: center;
   margin: 40px 0;
+  position: relative;
+  height: 200px;
 `
 
 const LoadMoreButton = styled.a`

--- a/src/components/fair/booth.tsx
+++ b/src/components/fair/booth.tsx
@@ -75,7 +75,7 @@ export class FairBooth extends React.Component<Props, State> {
               <PartnerText textSize="small" textStyle="primary">
                 {show.partner.name}
               </PartnerText>
-              <FollowButton type="profile" profile={show.partner.profile}/>
+              <FollowButton type="profile" artist={null} profile={show.partner.profile}/>
             </PartnerLine>
             {showLocation}
           </div>
@@ -136,6 +136,7 @@ export default Relay.createContainer(FairBooth, {
   fragments: {
     show: () => Relay.QL`
       fragment on Show {
+        __id
         name
         location {
           display
@@ -165,7 +166,7 @@ export default Relay.createContainer(FairBooth, {
 
 interface RelayProps {
   show: {
-    id: string | null,
+    __id: string | null,
     name: string | null,
     artworks: any,
     partner: {

--- a/src/components/fair/feed.tsx
+++ b/src/components/fair/feed.tsx
@@ -1,8 +1,6 @@
 import * as React from "react"
 import * as Relay from "react-relay"
 
-// import styled from "styled-components"
-
 import Booth from "./booth"
 
 const PageSize = 4

--- a/src/components/fair/feed.tsx
+++ b/src/components/fair/feed.tsx
@@ -1,0 +1,67 @@
+import * as React from "react"
+import * as Relay from "react-relay"
+
+// import styled from "styled-components"
+
+import Booth from "./booth"
+
+const PageSize = 4
+
+interface Props extends RelayProps, React.HTMLProps<ShowsFeed> {
+  section?: string,
+  sort?: string,
+  onContactGallery?: (showId: number) => any,
+}
+
+export class ShowsFeed extends React.Component<Props, null> {
+  render() {
+    const { fair } = this.props
+
+    const shows = fair.shows.edges.map(show => {
+      return (
+        <Booth show={show.node} key={show.cursor}/>
+      )
+    })
+
+    return (
+      <div className={this.props.className}>
+        {shows}
+      </div>
+    )
+  }
+}
+
+export default Relay.createContainer(ShowsFeed, {
+  initialVariables: {
+    showSize: PageSize,
+  },
+  fragments: {
+    fair: () => Relay.QL`
+      fragment on Fair {
+        id
+        shows: shows_connection(first: $showSize) {
+          pageInfo {
+            hasNextPage
+          }
+          edges {
+            id: cursor
+            node {
+              id
+              ${Booth.getFragment("show")}
+            }
+          }
+        }
+      }
+    `,
+  },
+})
+
+interface RelayProps {
+  fair: {
+    shows: {
+      pageInfo: {
+        hasNextPage: boolean,
+      },
+    } | any,
+  } | any
+}

--- a/src/components/fair/feed.tsx
+++ b/src/components/fair/feed.tsx
@@ -1,42 +1,116 @@
 import * as React from "react"
+import * as ReactDOM from "react-dom"
 import * as Relay from "react-relay"
 
+import styled from "styled-components"
+import colors from "../../assets/colors"
+
+import Spinner from "../spinner"
 import Booth from "./booth"
 
 const PageSize = 4
 
 interface Props extends RelayProps, React.HTMLProps<ShowsFeed> {
+  relay?: any,
   section?: string,
   sort?: string,
   onContactGallery?: (showId: number) => any,
 }
 
-export class ShowsFeed extends React.Component<Props, null> {
+interface State {
+  interval?: any,
+  loading: boolean,
+}
+
+export class ShowsFeed extends React.Component<Props, State> {
+  constructor(props) {
+    super(props)
+    this.state = {
+      interval: null,
+      loading: false,
+    }
+  }
+
+  componentDidMount() {
+    const interval = setInterval( () => { this.maybeLoadMore() }, 150 )
+    this.setState({ interval })
+  }
+
+  componentWillUnmount() {
+    if (this.state.interval) {
+      clearInterval(this.state.interval)
+    }
+  }
+
+  maybeLoadMore() {
+    const threshold = window.innerHeight + window.scrollY
+    const el = ReactDOM.findDOMNode(this)
+    if (threshold >= el.clientHeight + el.scrollTop) {
+      this.loadMoreShows()
+    }
+  }
+
+  loadMoreShows() {
+    const hasMore = this.props.fair.shows.pageInfo.hasNextPage
+    if (!this.state.loading && hasMore) {
+      this.setState({ loading: true }, () => {
+        this.props.relay.setVariables({
+          showsSize: this.props.relay.variables.showsSize + PageSize,
+        }, readyState => {
+          if (readyState.done) {
+            this.setState({ loading: false })
+          }
+        })
+      })
+    }
+  }
+
   render() {
     const { fair } = this.props
 
     const shows = fair.shows.edges.map(show => {
       return (
-        <Booth show={show.node} key={show.node.__id}/>
+        <BoothContainer>
+          <Booth show={show.node} key={show.node.__id}/>
+        </BoothContainer>
       )
     })
 
+    const spinner = this.state.loading && (
+      <SpinnerContainer>
+        <Spinner />
+      </SpinnerContainer>
+    )
+
     return (
-      <div className={this.props.className}>
+      <div>
         {shows}
+        {spinner}
       </div>
     )
   }
 }
 
+const BoothContainer = styled.div`
+  border-top: 1px solid ${colors.gray};
+  margin: 10px 0;
+  padding: 20px 0;
+`
+
+const SpinnerContainer = styled.div`
+  width: 100%;
+  height: 100px;
+  position: relative;
+`
+
 export default Relay.createContainer(ShowsFeed, {
   initialVariables: {
-    showSize: PageSize,
+    showsSize: PageSize,
   },
   fragments: {
     fair: () => Relay.QL`
       fragment on Fair {
-        shows: shows_connection(first: $showSize) {
+        shows: shows_connection(first: $showsSize, sort: FEATURED_DESC) {
           pageInfo {
             hasNextPage
           }

--- a/src/components/fair/feed.tsx
+++ b/src/components/fair/feed.tsx
@@ -14,7 +14,7 @@ interface Props extends RelayProps, React.HTMLProps<ShowsFeed> {
   relay?: any,
   section?: string,
   sort?: string,
-  onContactGallery?: (showId: number) => any,
+  onContactGallery?: (showId: string) => any,
 }
 
 interface State {

--- a/src/components/fair/feed.tsx
+++ b/src/components/fair/feed.tsx
@@ -17,7 +17,7 @@ export class ShowsFeed extends React.Component<Props, null> {
 
     const shows = fair.shows.edges.map(show => {
       return (
-        <Booth show={show.node} key={show.cursor}/>
+        <Booth show={show.node} key={show.node.__id}/>
       )
     })
 
@@ -42,7 +42,7 @@ export default Relay.createContainer(ShowsFeed, {
           }
           edges {
             node {
-              id
+              __id
               ${Booth.getFragment("show")}
             }
           }

--- a/src/components/fair/feed.tsx
+++ b/src/components/fair/feed.tsx
@@ -36,13 +36,11 @@ export default Relay.createContainer(ShowsFeed, {
   fragments: {
     fair: () => Relay.QL`
       fragment on Fair {
-        id
         shows: shows_connection(first: $showSize) {
           pageInfo {
             hasNextPage
           }
           edges {
-            id: cursor
             node {
               id
               ${Booth.getFragment("show")}

--- a/src/relay/queries/fair.ts
+++ b/src/relay/queries/fair.ts
@@ -1,0 +1,19 @@
+import * as Relay from "react-relay"
+
+export default class FairQueryConfig extends Relay.Route {
+  public static queries = {
+    fair: (component, params) => Relay.QL`
+      query {
+        fair(id: $fairID) {
+          ${component.getFragment("fair", params)}
+        }
+      }
+    `,
+  }
+
+  public static paramDefinitions = {
+    fairID: { required: true },
+  }
+
+  public static routeName = "FairQueryConfig"
+}


### PR DESCRIPTION
Getting some code up here, running into two errors: 1. The dreaded `Maximum call stack size exceeded` again, randomly. 2. `RelayQueryPath.getQuery(): Cannot generate accurate query for path with connection` when trying to load more artworks in an individual booth component.