### PR TITLE
Update to Artsy passport 2.x - Removes CoffeeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   "dependencies": {
     "@storybook/addon-options": "^3.1.2",
     "@storybook/react": "^3.1.3",
-    "artsy-passport": "^1.6.1",
+    "artsy-passport": "^2.0.3",
     "artsy-xapp": "^1.0.4",
     "babel-polyfill": "^6.23.0",
     "backbone": "^1.3.3",

--- a/src/apps/loyalty/server/index.tsx
+++ b/src/apps/loyalty/server/index.tsx
@@ -13,7 +13,7 @@ const { API_URL } = process.env
 
 app.use(express.static(path.resolve(__dirname)))
 
-const { loginPagePath } = artsyPassport.options
+const { loginPagePath } = (artsyPassport as any).options
 
 app.use(
   artsyPassport(

--- a/yarn.lock
+++ b/yarn.lock
@@ -503,13 +503,12 @@ arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-artsy-passport@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/artsy-passport/-/artsy-passport-1.6.1.tgz#82aad067999dfcdd929f3e33ed588ce1809762bd"
+artsy-passport@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/artsy-passport/-/artsy-passport-2.0.3.tgz#0a44b02e0adfecf8b04826ff8edee2506cef048b"
   dependencies:
     analytics-node "^2.1.0"
     async "^1.5.0"
-    coffee-script "^1.9.2"
     csurf "^1.8.3"
     dotenv "^4.0.0"
     express "^4.12.3"
@@ -2354,10 +2353,6 @@ coa@~1.0.1:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
-
-coffee-script@^1.9.2:
-  version "1.12.4"
-  resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.12.4.tgz#fe1bced97fe1fb3927b998f2b45616e0658be1ff"
 
 color-convert@^1.0.0, color-convert@^1.3.0:
   version "1.9.0"


### PR DESCRIPTION
This is the result of https://github.com/artsy/artsy-passport/pull/112 https://github.com/artsy/artsy-passport/pull/113 and https://github.com/artsy/artsy-passport/pull/114

It removes the only CoffeeScript dependency in reaction-force, and thus kills the need for the language inside the app.

Interestingly in doing so, TypeScript raised a compiler error because the typings could then be inferred . However, as `options` is added [dynamically](https://github.com/artsy/artsy-passport/blob/master/lib/index.coffee#L18) then it isn't seen. So I any'd it. If people care enough I can add types to the lib _ooooorrrrr_ someone else can, and I'll pair with them.